### PR TITLE
bugfix : file not found when absent students when adding grading scheme

### DIFF
--- a/examc_app/utils/amc_functions.py
+++ b/examc_app/utils/amc_functions.py
@@ -1090,13 +1090,13 @@ def add_grading_schemes_reports(exam_pk):
 
         # Optional: fail with a clearer message
         if not annotated_pdf_path.exists():
-            raise FileNotFoundError(f"Missing annotated PDF: {annotated_pdf_path}")
+            print(f"Missing annotated PDF: {annotated_pdf_path}")
+        else:
+            annotated_pdf_bytes = annotated_pdf_path.read_bytes()
+            grading_scheme_report_bytes = build_grading_report_pdf_bytes(exam_pk, student.id)
+            merged = concat_pdfs(annotated_pdf_bytes, grading_scheme_report_bytes)
 
-        annotated_pdf_bytes = annotated_pdf_path.read_bytes()
-        grading_scheme_report_bytes = build_grading_report_pdf_bytes(exam_pk, student.id)
-        merged = concat_pdfs(annotated_pdf_bytes, grading_scheme_report_bytes)
-
-        annotated_pdf_path.write_bytes(merged)
+            annotated_pdf_path.write_bytes(merged)
 
 def concat_pdfs(*pdfs_bytes: bytes) -> bytes:
     writer = PdfWriter()


### PR DESCRIPTION
# Pull Request

If student is absent, annotated pdf is not generated. When adding grading scheme at the end of annotated pdf, check before if file exists

## License
By submitting this PR, you agree that your contribution will be licensed under the  
**eXamc Non-Commercial License (NCL) v1.0**.
