### PR TITLE
infra: enable static asset cache-busting in production

### DIFF
--- a/examc/settings.py
+++ b/examc/settings.py
@@ -182,6 +182,21 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 STATIC_URL = '/static/'
 STATIC_ROOT = os.environ.get("STATIC_ROOT", "/static")
+STATIC_ASSET_VERSION = env("STATIC_ASSET_VERSION", APP_VERSION)
+
+# Avoid stale client-side assets after deploys:
+# - dev: plain static storage (no manifest requirement)
+# - test/prod: hashed filenames via manifest storage
+if DEBUG:
+    STORAGES = {
+        "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+        "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+    }
+else:
+    STORAGES = {
+        "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+        "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"},
+    }
 
 # Signed files expiration timeout ms
 SIGNED_FILES_EXPIRATION_TIMEOUT = 300
@@ -334,7 +349,7 @@ SUMMERNOTE_CONFIG = {
     "js": (
         # order matters a little less, but keep KaTeX before the plugin if the plugin calls it immediately
         "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-         f"{settings.STATIC_URL}js/summernote-math.js"
+         f"{settings.STATIC_URL}js/summernote-math.js?v={STATIC_ASSET_VERSION}"
     ),
     "attachment_storage_class": "examc_app.storage.SummernoteSignedPrivateStorage",
     # optional:

--- a/examc_app/templatetags/custom_tags.py
+++ b/examc_app/templatetags/custom_tags.py
@@ -7,6 +7,7 @@ from django import template
 from django.contrib.auth.models import User
 from django.db.models import FloatField, Sum
 from django.db.models.functions import Cast
+from django.templatetags.static import static
 from matplotlib.sphinxext.plot_directive import exception_template
 from shapely import Polygon
 
@@ -272,9 +273,9 @@ def get_sum_questions_points(exam_id):
 def get_logo_url():
     env = os.getenv("ENV")
     if env == 'prod':
-        return settings.STATIC_URL + "img/eXamc_bg_transp_200.png"
+        return static("img/eXamc_bg_transp_200.png")
     else:
-        return settings.STATIC_URL + "img/eXamc_bg_transp_200_dev.png"
+        return static("img/eXamc_bg_transp_200_dev.png")
 
 @register.filter
 def is_review_blocked(user_id,exam_id):
@@ -297,4 +298,3 @@ def get_by_first_element(lst, value):
     except Exception:
         return None
     return None
-


### PR DESCRIPTION
# Pull Request

## Description
• enable ManifestStaticFilesStorage when DEBUG=False for hashed static filenames
• keep plain static storage in DEBUG=True for local dev
• add STATIC_ASSET_VERSION and version summernote-math.js URL
• update get_logo_url to use static(...) so logo path is cache-busted too

 expected impact: fixes stale JS/CSS cache issues after deploy (like reviewGroup.js mismatch).

## License
By submitting this PR, you agree that your contribution will be licensed under the  
**eXamc Non-Commercial License (NCL) v1.0**.
