### PR TITLE
fix(review): sync grading progress and marker clearing behavior

### DIFF
--- a/examc_app/static/js/reviewGroup.js
+++ b/examc_app/static/js/reviewGroup.js
@@ -680,14 +680,19 @@
         });
 
         clearMarkersButton.addEventListener('click', function () {
-            const currentState = markerArea.getState();
-            currentState.markers = currentState.markers.filter(
-                m => m.typeName === 'HighlightMarker'
-            );
+            const currentState = keepCorrectorBoxMarkersOnly(markerArea.getState());
             allowHighlightOnlySaveOnce = true;
             restoreMarkerAreaState(currentState);
             layoutSourceImageAndBoxes();
-            onMarkerChange({allowHighlightOnly: true});
+            requestAnimationFrame(() => {
+                onMarkerChange({allowHighlightOnly: true, allowEmpty: true});
+                if (useGradingScheme) {
+                    const active = document.querySelector('a[id^="review-scheme-link-"].active');
+                    if (active) {
+                        setTimeout(() => sendScheme(active), 0);
+                    }
+                }
+            });
         });
 
         colorButton.addEventListener('click', (e) => {
@@ -698,9 +703,10 @@
         if (!deleteKeyHandlerBound) {
             deleteKeyHandlerBound = true;
             document.addEventListener('keydown', function (e) {
-                if (e.key === 'Delete') {
-                    const tag = document.activeElement && document.activeElement.tagName;
-                    if (tag === 'INPUT' || tag === 'TEXTAREA') {
+                if (e.key === 'Delete' || e.key === 'Backspace') {
+                    const activeElement = document.activeElement;
+                    const tag = activeElement && activeElement.tagName;
+                    if (tag === 'INPUT' || tag === 'TEXTAREA' || activeElement?.isContentEditable) {
                         return;
                     }
                     markerArea.deleteSelectedMarkers();
@@ -791,6 +797,13 @@
     function hasOnlyHighlightMarkers(state) {
         return Boolean(state?.markers?.length) &&
             state.markers.every(marker => marker.typeName === 'HighlightMarker');
+    }
+
+    function keepCorrectorBoxMarkersOnly(state) {
+        return {
+            ...state,
+            markers: (state.markers || []).filter(marker => marker.typeName === 'HighlightMarker')
+        };
     }
 
     // ---------------------------------------------------------------------------

--- a/examc_app/utils/review_functions.py
+++ b/examc_app/utils/review_functions.py
@@ -341,6 +341,16 @@ def get_copies_pages_by_group(pagesGroup):
         (row["copie_no"], row["page_no"]): bool(row["markers"]) and bool(row["correctorBoxMarked"])
         for row in scans_markers
     }
+    grading_scheme_marked_copies = set()
+    if pagesGroup.use_grading_scheme:
+        grading_scheme_marked_copies = {
+            str(copy_nr).zfill(4)
+            for copy_nr in (
+                PagesGroupGradingSchemeCheckedBox.objects
+                .filter(pages_group=pagesGroup)
+                .values_list("copy_nr", flat=True)
+            )
+        }
 
     # Comments -> set of copy_no strings
     comments_set = set(
@@ -411,7 +421,10 @@ def get_copies_pages_by_group(pagesGroup):
                 # Normalize keys like before
                 copy_no_z4 = str(copy_no).zfill(4)
                 page_no_norm = str(page_no_real).zfill(2).replace(".", "x")
-                marked = markers_idx.get((copy_no_z4, page_no_norm), False)
+                if pagesGroup.use_grading_scheme:
+                    marked = copy_no_z4 in grading_scheme_marked_copies and page_no_int == from_p
+                else:
+                    marked = markers_idx.get((copy_no_z4, page_no_norm), False)
                 copies_pages_list.append({
                     "copy_no": copy_no,
                     "page_no": page_no_real,


### PR DESCRIPTION

# Pull Request

## Description
fix(review): sync grading progress and marker clearing behavior

- mark grading-scheme reviewed copies from checked scheme boxes
- ignore manual page markers for graded status when grading schemes are used
- allow Backspace to delete selected review markers like Delete
- persist clear-marker actions after marker state restore
- preserve/reapply corrector-box highlights when clearing manual markers

