### PR TITLE
chore(security): limit Dependabot to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
+    groups:
+      python-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION


# Pull Request

## Description
- disable routine dependency version update PRs
- group Python security update PRs when available
- document security-only dependency update workflow