### PR TITLE
Optimization/dashboard + fix export marked files

### DIFF
--- a/examc_app/tasks.py
+++ b/examc_app/tasks.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 import shutil
 import time
+import uuid
 import zipfile
 from contextlib import closing
 from datetime import datetime, timedelta
@@ -336,7 +337,8 @@ def generate_marked_files_zip(self,exam_pk, export_type, with_comments):
         exam = Exam.objects.get(pk=exam_pk)
         scans_dir = str(settings.SCANS_ROOT) + "/" + str(exam.year.code) + "/" + str(exam.semester.code) + "/" + exam.code+"_"+exam.date.strftime("%Y%m%d")
         marked_dir = str(settings.MARKED_SCANS_ROOT) + "/" + str(exam.year.code) + "/" + str(exam.semester.code) + "/" + exam.code+"_"+exam.date.strftime("%Y%m%d")
-        export_subdir = 'marked_'+str(exam.year.code) + "_" + str(exam.semester.code) + "_" + exam.code + "_" + datetime.now().strftime('%Y%m%d%H%M%S%f')[:-5]
+        task_token = str(self.request.id or uuid.uuid4()).replace("-", "")
+        export_subdir = 'marked_'+str(exam.year.code) + "_" + str(exam.semester.code) + "_" + exam.code + "_" + datetime.now().strftime('%Y%m%d%H%M%S%f') + "_" + task_token[:12]
         export_subdir = export_subdir.replace(" ","_")
         export_tmp_dir = (str(settings.EXPORT_TMP_ROOT) + "/" + export_subdir)
 

--- a/examc_app/tests/test_dashboard.py
+++ b/examc_app/tests/test_dashboard.py
@@ -1,0 +1,185 @@
+from datetime import date
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import TestCase, override_settings
+
+from examc_app.models import (
+    AcademicYear,
+    Exam,
+    PageMarkers,
+    PagesGroup,
+    PagesGroupGradingSchemeCheckedBox,
+    Semester,
+)
+from examc_app.utils.dashboard import _add_manage_todos, _get_pages_group_progress, _get_review_progress
+
+
+class DashboardReviewProgressTestCase(TestCase):
+    def setUp(self):
+        self.scans_root = TemporaryDirectory()
+        self.addCleanup(self.scans_root.cleanup)
+        self.settings_override = override_settings(SCANS_ROOT=self.scans_root.name)
+        self.settings_override.enable()
+        self.addCleanup(self.settings_override.disable)
+
+        self.year = AcademicYear.objects.create(code="2025-2026", name="2025-2026")
+        self.semester = Semester.objects.create(code=1, name="Autumn")
+        self.exam = Exam.objects.create(
+            code="TEST-EXAM",
+            name="Test Exam",
+            semester=self.semester,
+            year=self.year,
+            date=date(2026, 1, 20),
+        )
+
+    def create_scan_copies(self, *copy_numbers):
+        scans_path = (
+            Path(self.scans_root.name)
+            / self.year.code
+            / str(self.semester.code)
+            / f"{self.exam.code}_{self.exam.date:%Y%m%d}"
+        )
+        for copy_number in copy_numbers:
+            (scans_path / copy_number).mkdir(parents=True, exist_ok=True)
+        return scans_path
+
+    def create_scan_file(self, copy_number, filename):
+        scans_path = self.create_scan_copies(copy_number)
+        scan_file = scans_path / copy_number / filename
+        scan_file.write_bytes(b"scan")
+        return scan_file
+
+    def test_pages_group_progress_uses_review_summary_copy_count(self):
+        self.create_scan_copies("0000", "0001", "0002", "0003", "0004")
+        pages_group = PagesGroup.objects.create(
+            exam=self.exam,
+            group_name="Q1",
+            nb_pages=1,
+        )
+        for copy_no in ("0001", "0002"):
+            PageMarkers.objects.create(
+                copie_no=copy_no,
+                page_no="01",
+                pages_group=pages_group,
+                filename=f"{copy_no}_01.jpg",
+                markers='{"markers":[{"typeName":"HighlightMarker"}]}',
+                exam=self.exam,
+                correctorBoxMarked=True,
+            )
+        PageMarkers.objects.create(
+            copie_no="0003",
+            page_no="01",
+            pages_group=pages_group,
+            filename="0003_01.jpg",
+            markers="",
+            exam=self.exam,
+            correctorBoxMarked=False,
+        )
+        PageMarkers.objects.create(
+            copie_no="CORR-BOX",
+            page_no="0",
+            pages_group=pages_group,
+            filename="corr-box.jpg",
+            markers='{"markers":[{"typeName":"HighlightMarker"}]}',
+            exam=self.exam,
+            correctorBoxMarked=True,
+        )
+
+        progress = _get_pages_group_progress(pages_group)
+
+        self.assertEqual(progress["graded"], 2)
+        self.assertEqual(progress["total"], 4)
+        self.assertEqual(progress["percent"], 50)
+
+    def test_review_progress_averages_question_progress(self):
+        self.create_scan_copies("0001", "0002", "0003", "0004")
+        first_group = PagesGroup.objects.create(
+            exam=self.exam,
+            group_name="Q1",
+            nb_pages=1,
+        )
+        PagesGroup.objects.create(
+            exam=self.exam,
+            group_name="Q2",
+            nb_pages=1,
+        )
+        for copy_no in ("0001", "0002", "0003", "0004"):
+            PageMarkers.objects.create(
+                copie_no=copy_no,
+                page_no="01",
+                pages_group=first_group,
+                filename=f"{copy_no}_01.jpg",
+                markers='{"markers":[{"typeName":"HighlightMarker"}]}',
+                exam=self.exam,
+                correctorBoxMarked=True,
+            )
+
+        progress = _get_review_progress(self.exam)
+
+        self.assertEqual(progress["graded"], 2)
+        self.assertEqual(progress["total"], 4)
+        self.assertEqual(progress["percent"], 50)
+
+    def test_grading_scheme_progress_counts_distinct_reviewed_copies(self):
+        self.create_scan_copies("0001", "0002", "0003")
+        pages_group = PagesGroup.objects.create(
+            exam=self.exam,
+            group_name="Q1",
+            nb_pages=1,
+            use_grading_scheme=True,
+        )
+        PagesGroupGradingSchemeCheckedBox.objects.create(
+            pages_group=pages_group,
+            copy_nr="0001",
+        )
+        PagesGroupGradingSchemeCheckedBox.objects.create(
+            pages_group=pages_group,
+            copy_nr="0001",
+        )
+        PagesGroupGradingSchemeCheckedBox.objects.create(
+            pages_group=pages_group,
+            copy_nr="0002",
+        )
+
+        progress = _get_pages_group_progress(pages_group)
+
+        self.assertEqual(progress["graded"], 2)
+        self.assertEqual(progress["total"], 3)
+        self.assertEqual(progress["percent"], 67)
+
+    def test_manage_todos_do_not_report_missing_scans_when_scan_files_exist(self):
+        self.exam.review_option = True
+        self.exam.save()
+        PagesGroup.objects.create(
+            exam=self.exam,
+            group_name="Q1",
+            nb_pages=1,
+        )
+        self.create_scan_file("0001", "copy_0001_01.jpg")
+
+        todos = []
+        _add_manage_todos(todos, self.exam)
+
+        self.assertFalse(any(
+            todo["description"] == "Review is enabled but no scanned page is available yet."
+            for todo in todos
+        ))
+
+    def test_manage_todos_report_missing_scans_when_no_scan_files_exist(self):
+        self.exam.review_option = True
+        self.exam.save()
+        PagesGroup.objects.create(
+            exam=self.exam,
+            group_name="Q1",
+            nb_pages=1,
+        )
+        self.create_scan_copies("0001")
+
+        todos = []
+        _add_manage_todos(todos, self.exam)
+
+        self.assertTrue(any(
+            todo["description"] == "Review is enabled but no scanned page is available yet."
+            for todo in todos
+        ))

--- a/examc_app/utils/dashboard.py
+++ b/examc_app/utils/dashboard.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from django.conf import settings
 from django.urls import reverse
 
@@ -98,29 +100,84 @@ def _get_exam_capabilities(user, exam_users):
 
 
 def _get_review_progress(exam):
-    markers = PageMarkers.objects.filter(exam=exam).exclude(copie_no="CORR-BOX")
-    total = markers.count()
-    if not total:
+    total_copies = _get_exam_review_copy_count(exam)
+    if not total_copies:
         return None
 
-    graded = markers.filter(correctorBoxMarked=True).count()
+    pages_groups_progress = [
+        progress
+        for progress in (
+            _get_pages_group_progress(pages_group, total_copies=total_copies)
+            for pages_group in exam.pagesGroup.all()
+        )
+        if progress["percent"] is not None
+    ]
+    if not pages_groups_progress:
+        return None
+
+    average_graded = sum(progress["graded"] for progress in pages_groups_progress) / len(pages_groups_progress)
     return {
-        "graded": graded,
-        "total": total,
-        "percent": round(100 / total * graded),
+        "graded": _format_progress_count(average_graded),
+        "total": total_copies,
+        "percent": round(100 / total_copies * average_graded),
     }
 
 
-def _get_pages_group_progress(pages_group, user_id=None):
+def _format_progress_count(count):
+    rounded_count = round(count, 1)
+    if rounded_count == int(rounded_count):
+        return int(rounded_count)
+    return rounded_count
+
+
+def _get_exam_review_scans_path(exam):
+    if not exam.year_id or not exam.semester_id or not exam.date:
+        return None
+
+    scans_path = (
+        Path(settings.SCANS_ROOT)
+        / str(exam.year.code)
+        / str(exam.semester.code)
+        / f"{exam.code}_{exam.date:%Y%m%d}"
+    )
+    if not scans_path.is_dir():
+        return None
+
+    return scans_path
+
+
+def _get_exam_review_copy_dirs(exam):
+    scans_path = _get_exam_review_scans_path(exam)
+    if not scans_path:
+        return []
+
+    return [
+        scan_path
+        for scan_path in scans_path.iterdir()
+        if scan_path.is_dir() and scan_path.name != "0000"
+    ]
+
+
+def _get_exam_review_copy_count(exam):
+    return len(_get_exam_review_copy_dirs(exam))
+
+
+def _exam_has_review_scan_files(exam):
+    for copy_path in _get_exam_review_copy_dirs(exam):
+        if any(scan_path.is_file() for scan_path in copy_path.iterdir()):
+            return True
+    return False
+
+
+def _get_pages_group_progress(pages_group, user_id=None, total_copies=None):
+    total = total_copies if total_copies is not None else _get_exam_review_copy_count(pages_group.exam)
     markers = PageMarkers.objects.filter(pages_group=pages_group).exclude(copie_no="CORR-BOX")
     if pages_group.use_grading_scheme:
-        total = markers.values("copie_no").distinct().count()
         graded = PagesGroupGradingSchemeCheckedBox.objects.filter(pages_group=pages_group)
         if user_id:
             graded = graded.filter(user_id=user_id)
         graded_count = graded.values("copy_nr").distinct().count()
     else:
-        total = markers.count()
         graded = markers.filter(correctorBoxMarked=True)
         if user_id:
             graded = graded.filter(pageMarkers_users__user_id=user_id).distinct()
@@ -232,7 +289,7 @@ def _add_manage_todos(todos, exam):
                     reverse("reviewSettingsView", kwargs={"exam_pk": exam.pk, "curr_tab": "reviewers"}),
                     "fa-user-plus",
                 )
-            if not PageMarkers.objects.filter(exam=exam).exclude(copie_no="CORR-BOX").exists():
+            if not _exam_has_review_scan_files(exam):
                 _add_todo(
                     todos,
                     f"{exam.code}: upload scans",

--- a/examc_app/views/review_views.py
+++ b/examc_app/views/review_views.py
@@ -466,8 +466,6 @@ def generate_marked_files(request, exam_pk, task_id=None):
     """
           Export all the marked files.
 
-          This function is used to export all the marked files and will delete old folders and zips folder.
-
           Args:
             request: TThe HTTP request object.
             pk: The primary key of the exam.
@@ -480,18 +478,6 @@ def generate_marked_files(request, exam_pk, task_id=None):
     if user_allowed(exam, request.user.id):
 
         if request.method == 'POST':
-
-            # delete old tmp folders and zips
-            for filename in os.listdir(str(settings.EXPORT_TMP_ROOT)):
-                file_path = os.path.join(str(settings.EXPORT_TMP_ROOT), filename)
-                try:
-                    if os.path.isfile(file_path) or os.path.islink(file_path):
-                        os.unlink(file_path)
-                    elif os.path.isdir(file_path):
-                        shutil.rmtree(file_path)
-                except Exception as e:
-                    print('Failed to delete %s. Reason: %s' % (file_path, e))
-
             form = ExportMarkedFilesForm(request.POST, exam=exam)
 
             if form.is_valid():

--- a/templates/base.html
+++ b/templates/base.html
@@ -509,7 +509,7 @@ function processResult(resultElement, result) {
         }, 1000);
     }else if(result.startsWith('marked_') && result.endsWith(".zip")){        
         var link = document.createElement('a');
-        link.href = "/download_marked_files/"+result;
+        link.href = "/download_marked_files/" + encodeURIComponent(result) + "/{{ exam_selected.pk }}";
         link.download = 'Click to download marked files';
         link.innerText = 'Click to download marked files';
         progressBarElement = document.getElementById('progress-bar-message');


### PR DESCRIPTION

## Description
Optimization My Exams review progress and To-Do list 
Stop deleting all export temp files before starting a marked scan export,
because concurrent exports could remove another user's completed zip.

Make export zip names task-specific and fix the generated download URL to
include the required exam id.

